### PR TITLE
 Correct statement and example about shift expressions

### DIFF
--- a/2018/go-1.10-release-party/presentation.slide
+++ b/2018/go-1.10-release-party/presentation.slide
@@ -73,7 +73,7 @@ First, the compilers have been updated to allow the index expression *x[1.0*<<*s
     package main
 
     func main() {
-        const s = 10
+        var s uint = 10
         a := make([]byte, 1.0<<s) // valid
         _ = a[1.0<<s]             // in Go 1.9 accepted by go/types, not accepted by cmd/compile
     }

--- a/2018/go-1.10-release-party/presentation.slide
+++ b/2018/go-1.10-release-party/presentation.slide
@@ -68,7 +68,7 @@ However, there are a couple of minor changes.
 
 * Language Changes
 
-First, the compilers have been updated to allow the index expression *x[1.0*<<*s]* where *s* is an *untyped*constant*
+First, the compilers have been updated to allow the index expression *x[1.0*<<*s]* where *s* is an *unsigned*integer*
 
     package main
 


### PR DESCRIPTION
I recently noticed that the original Go 1.10 Release Notes had a small confusion regarding the type of s in the example snippet. The correction is being proposed in CL 108676 (https://go-review.googlesource.com/c/go/+/108676).

#2 attempted to fix the example by following what the description said. But the description was wrong, and the example was correct.

This change reverts #2 and correctly characterizes the type of s in the description.

See the commit message in 2d1d48772202ff34af4090ef16693eeb28e1f5ee for a command line walkthrough showing that `const s` sees no behavior change from go1.9 to go1.10, and `var s uint` was indeed the intended type.